### PR TITLE
Google Calendar subscription groundwork for Konsensus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 VITE_VAPID_PUBLIC_KEY=your_vapid_public_key_here
 VITE_SAVE_SUB_URL=your_save_subscription_url_here
 VITE_SEND_PUSH_URL=your_send_push_url_here
+
+# Konsensus (Google Calendar public subscription)
+# Public Google Calendar subscription URL. Keep personal account addresses out of the frontend.
+VITE_CONSENSUS_CALENDAR_URL=your_public_google_calendar_subscription_url_here

--- a/docs/CONSENSUS_GOOGLE_CALENDAR.md
+++ b/docs/CONSENSUS_GOOGLE_CALENDAR.md
@@ -1,0 +1,63 @@
+# Konsensus Google Calendar entegrasyonu
+
+## Amaç
+
+`meetings` tablosu tek kaynak olarak kalır. Google Calendar yalnızca yayınlanan bir ayna takvimdir.
+
+Akış:
+
+`Konsensus Yönetim -> Supabase meetings -> sunucu tarafı senkron -> Google Calendar -> takipçiler`
+
+Bu tasarımda kullanıcılar Google Takvim'i bir kez takip eder; toplantı ekleme, tarih/saat değiştirme ve silme işlemleri daha sonra merkezi sistemden yönetilir.
+
+## Hesap modeli
+
+Kişisel Google hesabı kullanılmamalıdır. Yalnızca bu servis için ayrı, ücretsiz bir Google hesabı kullanılmalıdır (ör. `patolojikonsensus@gmail.com`).
+
+- Kişisel Gmail adresi frontend'e veya git geçmişine yazılmaz.
+- OAuth client secret, refresh token ve benzeri kimlik bilgileri yalnız sunucu tarafı secret olarak tutulur.
+- Frontend yalnız herkese açık takvim abonelik URL'sini görür.
+- Takvim adı önerisi: **Patoloji Konsensus**.
+
+## Frontend yapılandırması
+
+`.env` içinde:
+
+```env
+VITE_CONSENSUS_CALENDAR_URL=https://calendar.google.com/...
+```
+
+Bu değer tanımlı değilse `/konsensus` sayfasında Google Takvim butonu gösterilmez.
+
+## Senkronizasyon için planlanan alan
+
+`meetings` tablosunda her toplantıyı Google etkinliği ile eşleştirmek için sunucu tarafında bir `google_event_id` alanı tutulmalıdır.
+
+Önerilen davranış:
+
+- INSERT -> Google etkinliği oluştur, `google_event_id` kaydet.
+- UPDATE -> mevcut Google etkinliğini güncelle.
+- DELETE -> Google etkinliğini sil.
+- Tekrar denemelerde aynı toplantının ikinci kez oluşturulmaması için işlem idempotent olmalıdır.
+
+## Güvenlik
+
+Aşağıdaki değerler hiçbir zaman `VITE_` değişkeni veya repository dosyası olarak tutulmamalıdır:
+
+- Google OAuth client secret
+- Google OAuth refresh token
+- Google service-account private key (ileride kullanılırsa)
+
+Bunlar yalnız Supabase/hosting sunucu tarafı secrets alanında tutulmalıdır.
+
+## Uygulama sırası
+
+1. Ayrı Google hesabı oluştur.
+2. Bu hesapta `Patoloji Konsensus` adlı ayrı takvim oluştur.
+3. Takvimi herkese açık, yalnız görüntülenebilir biçimde paylaş ve abonelik URL'sini al.
+4. `VITE_CONSENSUS_CALENDAR_URL` değerini deployment ortamına ekle.
+5. Google Cloud projesinde Calendar API'yi etkinleştir.
+6. Sunucu tarafı OAuth/offline erişimi yapılandır.
+7. `meetings` -> Google Calendar create/update/delete senkronunu ekle.
+8. Mevcut toplantıları ilk kez Google Calendar'a aktar.
+

--- a/docs/CONSENSUS_GOOGLE_CALENDAR.md
+++ b/docs/CONSENSUS_GOOGLE_CALENDAR.md
@@ -10,14 +10,31 @@ Akış:
 
 Bu tasarımda kullanıcılar Google Takvim'i bir kez takip eder; toplantı ekleme, tarih/saat değiştirme ve silme işlemleri daha sonra merkezi sistemden yönetilir.
 
-## Hesap modeli
+## Yayın hesabı ve takvim
 
-Kişisel Google hesabı kullanılmamalıdır. Yalnızca bu servis için ayrı, ücretsiz bir Google hesabı kullanılmalıdır (ör. `patolojikonsensus@gmail.com`).
+Yayın hesabı: `patolojikonsensus@gmail.com`
 
-- Kişisel Gmail adresi frontend'e veya git geçmişine yazılmaz.
-- OAuth client secret, refresh token ve benzeri kimlik bilgileri yalnız sunucu tarafı secret olarak tutulur.
-- Frontend yalnız herkese açık takvim abonelik URL'sini görür.
-- Takvim adı önerisi: **Patoloji Konsensus**.
+Takvim adı: **Patoloji Konsensus**
+
+Takvim kimliği:
+
+```text
+a6f960d17e45d61857426577e15c58493e76f69fdf8e62ae11d2ae238140d82e@group.calendar.google.com
+```
+
+Takvim herkese açık ve takipçiler için yalnız görüntülenebilir kalır. Frontend yalnız herkese açık Google Calendar abonelik URL'sini kullanır.
+
+## Etkinlik içeriği
+
+Google Calendar etkinlikleri reklam veya kişisel site yönlendirmesi içermemelidir. Güncel katılım bilgileri için nötr takip sayfası kullanılır:
+
+```text
+https://konsensus.bolt.host/
+```
+
+`metinciris.com.tr/konsensus` bu entegrasyonda etkinlik açıklamasına eklenmez; yedek sistem olarak bağımsız kalır.
+
+Zoom bağlantısı, toplantı kimliği ve parola Google Calendar'a kalıcı olarak yazılmaz. Böylece mevcut zaman kontrollü Zoom görünürlüğü korunur.
 
 ## Frontend yapılandırması
 
@@ -28,6 +45,19 @@ VITE_CONSENSUS_CALENDAR_URL=https://calendar.google.com/...
 ```
 
 Bu değer tanımlı değilse `/konsensus` sayfasında Google Takvim butonu gösterilmez.
+
+## Kimlik doğrulama modeli
+
+Senkronizasyon için kullanıcı OAuth/refresh-token akışı yerine ayrı bir **Google Cloud service account** kullanılacaktır.
+
+- Google Cloud projesinde Calendar API etkinleştirilir.
+- `konsensus-calendar-sync` benzeri bir service account oluşturulur.
+- `Patoloji Konsensus` takvimi bu service-account e-posta adresiyle paylaşılır.
+- Service account'a yalnız **Etkinliklerde değişiklik yapma / Make changes to events** yetkisi verilir; paylaşımı yönetme yetkisi verilmez.
+- Service-account JSON anahtarı yalnız sunucu tarafı secret olarak saklanır.
+- Private key, JSON anahtar dosyası veya başka kimlik bilgileri repository'ye ya da `VITE_` değişkenlerine yazılmaz.
+
+Bu modelde OAuth consent screen, kullanıcı oturumu ve refresh token gerekmez.
 
 ## Senkronizasyon için planlanan alan
 
@@ -44,20 +74,22 @@ Bu değer tanımlı değilse `/konsensus` sayfasında Google Takvim butonu göst
 
 Aşağıdaki değerler hiçbir zaman `VITE_` değişkeni veya repository dosyası olarak tutulmamalıdır:
 
-- Google OAuth client secret
-- Google OAuth refresh token
-- Google service-account private key (ileride kullanılırsa)
+- Google service-account private key
+- Service-account JSON credential
+- Sunucu tarafı erişim tokenları
 
-Bunlar yalnız Supabase/hosting sunucu tarafı secrets alanında tutulmalıdır.
+Bunlar yalnız Supabase Edge Function secrets alanında tutulmalıdır.
 
 ## Uygulama sırası
 
-1. Ayrı Google hesabı oluştur.
-2. Bu hesapta `Patoloji Konsensus` adlı ayrı takvim oluştur.
-3. Takvimi herkese açık, yalnız görüntülenebilir biçimde paylaş ve abonelik URL'sini al.
-4. `VITE_CONSENSUS_CALENDAR_URL` değerini deployment ortamına ekle.
-5. Google Cloud projesinde Calendar API'yi etkinleştir.
-6. Sunucu tarafı OAuth/offline erişimi yapılandır.
-7. `meetings` -> Google Calendar create/update/delete senkronunu ekle.
-8. Mevcut toplantıları ilk kez Google Calendar'a aktar.
-
+1. Ayrı Google hesabı oluştur. ✅
+2. Bu hesapta `Patoloji Konsensus` adlı ayrı takvim oluştur. ✅
+3. Takvimi herkese açık, yalnız görüntülenebilir biçimde paylaş ve abonelik URL'sini al. ✅
+4. Google Cloud projesinde Calendar API'yi etkinleştir.
+5. `konsensus-calendar-sync` service account oluştur.
+6. `Patoloji Konsensus` takvimini service account ile `Make changes to events` yetkisiyle paylaş.
+7. Service-account credential bilgisini Supabase secret olarak ekle.
+8. `meetings.google_event_id` alanını ekle.
+9. Supabase Edge Function ile create/update/delete senkronunu ekle.
+10. Mevcut gelecek toplantıları ilk kez Google Calendar'a aktar.
+11. Public Google Calendar abonelik URL'sini deployment ortamına ekle.

--- a/docs/CONSENSUS_GOOGLE_CALENDAR.md
+++ b/docs/CONSENSUS_GOOGLE_CALENDAR.md
@@ -6,7 +6,7 @@
 
 Akış:
 
-`Konsensus Yönetim -> Supabase meetings -> sunucu tarafı senkron -> Google Calendar -> takipçiler`
+`Konsensus Yönetim -> Supabase meetings -> Edge Function -> Google Calendar -> takipçiler`
 
 Bu tasarımda kullanıcılar Google Takvim'i bir kez takip eder; toplantı ekleme, tarih/saat değiştirme ve silme işlemleri daha sonra merkezi sistemden yönetilir.
 
@@ -22,7 +22,13 @@ Takvim kimliği:
 a6f960d17e45d61857426577e15c58493e76f69fdf8e62ae11d2ae238140d82e@group.calendar.google.com
 ```
 
-Takvim herkese açık ve takipçiler için yalnız görüntülenebilir kalır. Frontend yalnız herkese açık Google Calendar abonelik URL'sini kullanır.
+Service account:
+
+```text
+konsensus-calendar-sync@patoloji-konsensus.iam.gserviceaccount.com
+```
+
+Takvim herkese açık ve takipçiler için yalnız görüntülenebilir kalır. Service account'a yalnız **Etkinliklerde değişiklik yapma / Make changes to events** yetkisi verilir.
 
 ## Etkinlik içeriği
 
@@ -38,58 +44,117 @@ Zoom bağlantısı, toplantı kimliği ve parola Google Calendar'a kalıcı olar
 
 ## Frontend yapılandırması
 
-`.env` içinde:
+Deployment `.env` içinde public abonelik bağlantısı tanımlanır:
 
 ```env
-VITE_CONSENSUS_CALENDAR_URL=https://calendar.google.com/...
+VITE_CONSENSUS_CALENDAR_URL=https://calendar.google.com/calendar/u/0?cid=YTZmOTYwZDE3ZTQ1ZDYxODU3NDI2NTc3ZTE1YzU4NDkzZTc2ZjY5ZmRmOGU2MmFlMTFkMmFlMjM4MTQwZDgyZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
 ```
 
 Bu değer tanımlı değilse `/konsensus` sayfasında Google Takvim butonu gösterilmez.
 
 ## Kimlik doğrulama modeli
 
-Senkronizasyon için kullanıcı OAuth/refresh-token akışı yerine ayrı bir **Google Cloud service account** kullanılacaktır.
+Senkronizasyon kullanıcı OAuth/refresh-token akışı yerine Google Cloud **service account** ile yapılır.
 
-- Google Cloud projesinde Calendar API etkinleştirilir.
-- `konsensus-calendar-sync` benzeri bir service account oluşturulur.
-- `Patoloji Konsensus` takvimi bu service-account e-posta adresiyle paylaşılır.
-- Service account'a yalnız **Etkinliklerde değişiklik yapma / Make changes to events** yetkisi verilir; paylaşımı yönetme yetkisi verilmez.
-- Service-account JSON anahtarı yalnız sunucu tarafı secret olarak saklanır.
-- Private key, JSON anahtar dosyası veya başka kimlik bilgileri repository'ye ya da `VITE_` değişkenlerine yazılmaz.
+- Google Calendar API etkin olmalıdır.
+- Service account JSON anahtarı yalnız Supabase secret olarak saklanır.
+- Private key veya JSON anahtar dosyası repository'ye ya da `VITE_` değişkenlerine yazılmaz.
+- Edge Function yalnız `calendar.events` OAuth kapsamını ister.
 
 Bu modelde OAuth consent screen, kullanıcı oturumu ve refresh token gerekmez.
 
-## Senkronizasyon için planlanan alan
+## Deterministik Google event ID
 
-`meetings` tablosunda her toplantıyı Google etkinliği ile eşleştirmek için sunucu tarafında bir `google_event_id` alanı tutulmalıdır.
+`meetings.google_event_id` sütunu eklenmez. Her toplantının Supabase `id` değerinden SHA-256 tabanlı, Google Calendar tarafından kabul edilen stabil bir event ID üretilir.
 
-Önerilen davranış:
+Bunun yararları:
 
-- INSERT -> Google etkinliği oluştur, `google_event_id` kaydet.
-- UPDATE -> mevcut Google etkinliğini güncelle.
-- DELETE -> Google etkinliğini sil.
-- Tekrar denemelerde aynı toplantının ikinci kez oluşturulmaması için işlem idempotent olmalıdır.
+- INSERT/UPDATE webhook tekrarları duplicate etkinlik oluşturmaz.
+- Ek bir veritabanı sütunu gerekmez.
+- `google_event_id` yazılması nedeniyle ikinci bir UPDATE webhook döngüsü oluşmaz.
+- DELETE sırasında aynı event ID yeniden hesaplanabilir.
 
-## Güvenlik
+## Edge Function secrets
 
-Aşağıdaki değerler hiçbir zaman `VITE_` değişkeni veya repository dosyası olarak tutulmamalıdır:
+Supabase Dashboard -> Edge Functions -> Secrets alanında aşağıdaki secret'lar bulunmalıdır:
 
-- Google service-account private key
-- Service-account JSON credential
-- Sunucu tarafı erişim tokenları
+```text
+GOOGLE_CALENDAR_ID
+GOOGLE_SERVICE_ACCOUNT_JSON
+CONSENSUS_PUBLIC_URL
+CONSENSUS_CALENDAR_WEBHOOK_SECRET
+```
 
-Bunlar yalnız Supabase Edge Function secrets alanında tutulmalıdır.
+Değerler:
+
+```text
+GOOGLE_CALENDAR_ID=a6f960d17e45d61857426577e15c58493e76f69fdf8e62ae11d2ae238140d82e@group.calendar.google.com
+CONSENSUS_PUBLIC_URL=https://konsensus.bolt.host/
+```
+
+`GOOGLE_SERVICE_ACCOUNT_JSON`, Google Cloud'dan indirilen JSON anahtar dosyasının **tam içeriğidir**. Bu içerik GitHub'a yüklenmez.
+
+`CONSENSUS_CALENDAR_WEBHOOK_SECRET` rastgele ve uzun bir değerdir. Aynı değer Database Webhook'un `x-consensus-webhook-secret` HTTP header'ında kullanılır.
+
+## Edge Function
+
+Kod:
+
+```text
+supabase/functions/sync-consensus-calendar/index.ts
+```
+
+Fonksiyon yalnız Database Webhook'tan çağrılır. Supabase JWT doğrulaması bu fonksiyon için kapalıdır; bunun yerine `x-consensus-webhook-secret` zorunludur.
+
+Fonksiyon davranışı:
+
+- INSERT -> deterministik ID ile event oluştur / varsa güncelle.
+- UPDATE -> aynı event'i güncelle.
+- DELETE -> aynı event'i sil; zaten yoksa başarılı kabul et.
+- Google Calendar daveti göndermez (`sendUpdates=none`).
+
+## Database Webhook
+
+Supabase Dashboard -> Database -> Webhooks bölümünde `public.meetings` tablosu için bir webhook oluşturulur.
+
+Events:
+
+```text
+INSERT
+UPDATE
+DELETE
+```
+
+HTTP method:
+
+```text
+POST
+```
+
+URL:
+
+```text
+https://<SUPABASE_PROJECT_REF>.supabase.co/functions/v1/sync-consensus-calendar
+```
+
+Header:
+
+```text
+x-consensus-webhook-secret: <CONSENSUS_CALENDAR_WEBHOOK_SECRET ile aynı değer>
+```
 
 ## Uygulama sırası
 
 1. Ayrı Google hesabı oluştur. ✅
-2. Bu hesapta `Patoloji Konsensus` adlı ayrı takvim oluştur. ✅
-3. Takvimi herkese açık, yalnız görüntülenebilir biçimde paylaş ve abonelik URL'sini al. ✅
-4. Google Cloud projesinde Calendar API'yi etkinleştir.
-5. `konsensus-calendar-sync` service account oluştur.
-6. `Patoloji Konsensus` takvimini service account ile `Make changes to events` yetkisiyle paylaş.
-7. Service-account credential bilgisini Supabase secret olarak ekle.
-8. `meetings.google_event_id` alanını ekle.
-9. Supabase Edge Function ile create/update/delete senkronunu ekle.
-10. Mevcut gelecek toplantıları ilk kez Google Calendar'a aktar.
-11. Public Google Calendar abonelik URL'sini deployment ortamına ekle.
+2. `Patoloji Konsensus` takvimini oluştur. ✅
+3. Takvimi herkese açık, yalnız görüntülenebilir paylaş. ✅
+4. Google Calendar API'yi etkinleştir. ✅
+5. `konsensus-calendar-sync` service account oluştur. ✅
+6. Takvimi service account ile `Make changes to events` yetkisiyle paylaş. ✅
+7. Google Cloud'da service account JSON key oluştur.
+8. Supabase secrets değerlerini ekle.
+9. Edge Function'ı deploy et.
+10. `meetings` INSERT/UPDATE/DELETE Database Webhook'unu oluştur.
+11. Tek bir test toplantısı ile create/update/delete senkronunu doğrula.
+12. Mevcut gelecek toplantıları backfill et.
+13. Public Google Calendar abonelik URL'sini deployment ortamına ekle.

--- a/src/components/Konsensus/NotificationsCard.tsx
+++ b/src/components/Konsensus/NotificationsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bell } from 'lucide-react';
+import { Bell, CalendarPlus, ExternalLink } from 'lucide-react';
 
 export function NotificationsCard({
     pushEnabled,
@@ -10,6 +10,8 @@ export function NotificationsCard({
     pushLoading: boolean;
     togglePush: () => void;
 }) {
+    const calendarUrl = (import.meta.env.VITE_CONSENSUS_CALENDAR_URL ?? '').trim();
+
     return (
         <div className="bg-white rounded-3xl shadow-xl p-6 sm:p-7 border border-gray-100">
             <div className="flex items-start justify-between gap-3">
@@ -41,6 +43,31 @@ export function NotificationsCard({
             >
                 {pushLoading ? 'İşlem…' : pushEnabled ? 'Bildirimleri kapat' : 'Bildirimleri etkinleştir'}
             </button>
+
+            {calendarUrl && (
+                <div className="mt-5 pt-5 border-t border-gray-100">
+                    <div className="flex items-start gap-3">
+                        <div className="p-2.5 rounded-2xl bg-emerald-50 text-emerald-700">
+                            <CalendarPlus className="w-5 h-5" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                            <div className="font-black text-gray-900">Konsensus Takvimi</div>
+                            <div className="text-sm text-gray-500 mt-1">
+                                Google Takvim’e bir kez ekleyin; toplantı tarih ve saat değişiklikleri takviminize yansısın.
+                            </div>
+                            <a
+                                href={calendarUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="mt-3 inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2.5 rounded-2xl bg-emerald-600 text-white font-black hover:bg-emerald-700 transition shadow-md shadow-emerald-100"
+                            >
+                                Google Takvim’de takip et
+                                <ExternalLink className="w-4 h-4" />
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/Konsensus/NotificationsCard.tsx
+++ b/src/components/Konsensus/NotificationsCard.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Bell, CalendarPlus, ExternalLink } from 'lucide-react';
 
+const GOOGLE_CALENDAR_URL = 'https://calendar.google.com/calendar/u/0?cid=YTZmOTYwZDE3ZTQ1ZDYxODU3NDI2NTc3ZTE1YzU4NDkzZTc2ZjY5ZmRmOGU2MmFlMTFkMmFlMjM4MTQwZDgyZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t';
+const ICAL_URL = 'https://calendar.google.com/calendar/ical/a6f960d17e45d61857426577e15c58493e76f69fdf8e62ae11d2ae238140d82e%40group.calendar.google.com/public/basic.ics';
+
 export function NotificationsCard({
     pushEnabled,
     pushLoading,
@@ -10,8 +13,6 @@ export function NotificationsCard({
     pushLoading: boolean;
     togglePush: () => void;
 }) {
-    const calendarUrl = (import.meta.env.VITE_CONSENSUS_CALENDAR_URL ?? '').trim();
-
     return (
         <div className="bg-white rounded-3xl shadow-xl p-6 sm:p-7 border border-gray-100">
             <div className="flex items-start justify-between gap-3">
@@ -44,30 +45,45 @@ export function NotificationsCard({
                 {pushLoading ? 'İşlem…' : pushEnabled ? 'Bildirimleri kapat' : 'Bildirimleri etkinleştir'}
             </button>
 
-            {calendarUrl && (
-                <div className="mt-5 pt-5 border-t border-gray-100">
-                    <div className="flex items-start gap-3">
-                        <div className="p-2.5 rounded-2xl bg-emerald-50 text-emerald-700">
-                            <CalendarPlus className="w-5 h-5" />
+            <div className="mt-5 pt-5 border-t border-gray-100">
+                <div className="flex items-start gap-3">
+                    <div className="p-2.5 rounded-2xl bg-emerald-50 text-emerald-700">
+                        <CalendarPlus className="w-5 h-5" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        <div className="font-black text-gray-900">Patoloji Konsensus Takvimi</div>
+                        <div className="text-sm text-gray-500 mt-1">
+                            Takvimi bir kez ekleyin; yeni toplantılar ve tarih-saat değişiklikleri otomatik olarak takviminize yansısın.
                         </div>
-                        <div className="min-w-0 flex-1">
-                            <div className="font-black text-gray-900">Konsensus Takvimi</div>
-                            <div className="text-sm text-gray-500 mt-1">
-                                Google Takvim’e bir kez ekleyin; toplantı tarih ve saat değişiklikleri takviminize yansısın.
-                            </div>
+
+                        <div className="mt-3 flex flex-col sm:flex-row gap-2">
                             <a
-                                href={calendarUrl}
+                                href={GOOGLE_CALENDAR_URL}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="mt-3 inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2.5 rounded-2xl bg-emerald-600 text-white font-black hover:bg-emerald-700 transition shadow-md shadow-emerald-100"
+                                className="inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2.5 rounded-2xl bg-emerald-600 text-white font-black hover:bg-emerald-700 transition shadow-md shadow-emerald-100"
                             >
-                                Google Takvim’de takip et
+                                Google Takvim’e ekle
+                                <ExternalLink className="w-4 h-4" />
+                            </a>
+
+                            <a
+                                href={ICAL_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2.5 rounded-2xl bg-gray-100 text-gray-700 font-black hover:bg-gray-200 transition"
+                            >
+                                Apple / Outlook / iCal
                                 <ExternalLink className="w-4 h-4" />
                             </a>
                         </div>
+
+                        <div className="text-xs text-gray-400 mt-2">
+                            Google Takvim’e ilk ekleme işlemi bilgisayar tarayıcısında daha sorunsuz çalışır.
+                        </div>
                     </div>
                 </div>
-            )}
+            </div>
         </div>
     );
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,2 @@
+[functions.sync-consensus-calendar]
+verify_jwt = false

--- a/supabase/functions/sync-consensus-calendar/index.ts
+++ b/supabase/functions/sync-consensus-calendar/index.ts
@@ -1,0 +1,340 @@
+type MeetingRecord = {
+  id: string | number;
+  title: string;
+  organizer?: string | null;
+  date: string;
+  time?: string | null;
+  duration?: number | null;
+  description?: string | null;
+};
+
+type WebhookPayload = {
+  type: 'INSERT' | 'UPDATE' | 'DELETE';
+  table: string;
+  schema: string;
+  record: MeetingRecord | null;
+  old_record: MeetingRecord | null;
+};
+
+type ServiceAccountCredentials = {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+};
+
+const GOOGLE_SCOPE = 'https://www.googleapis.com/auth/calendar.events';
+const GOOGLE_API = 'https://www.googleapis.com/calendar/v3';
+const TIME_ZONE = 'Europe/Istanbul';
+
+function getRequiredEnv(name: string): string {
+  const value = Deno.env.get(name)?.trim();
+  if (!value) throw new Error(`Missing required secret: ${name}`);
+  return value;
+}
+
+function jsonResponse(status: number, body: Record<string, unknown>) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function textToBase64Url(value: string): string {
+  return bytesToBase64Url(new TextEncoder().encode(value));
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const clean = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/g, '')
+    .replace(/-----END PRIVATE KEY-----/g, '')
+    .replace(/\s+/g, '');
+
+  const binary = atob(clean);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
+async function getGoogleAccessToken(credentials: ServiceAccountCredentials): Promise<string> {
+  const tokenUri = credentials.token_uri || 'https://oauth2.googleapis.com/token';
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = textToBase64Url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const claims = textToBase64Url(
+    JSON.stringify({
+      iss: credentials.client_email,
+      scope: GOOGLE_SCOPE,
+      aud: tokenUri,
+      iat: now - 30,
+      exp: now + 3600,
+    }),
+  );
+
+  const unsignedJwt = `${header}.${claims}`;
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToArrayBuffer(credentials.private_key),
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(unsignedJwt),
+  );
+
+  const assertion = `${unsignedJwt}.${bytesToBase64Url(new Uint8Array(signature))}`;
+  const response = await fetch(tokenUri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok || !data.access_token) {
+    throw new Error(`Google token request failed (${response.status}): ${JSON.stringify(data)}`);
+  }
+
+  return data.access_token as string;
+}
+
+async function deterministicEventId(meetingId: string | number): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(String(meetingId)),
+  );
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+  // Google Calendar custom IDs allow base32hex characters (0-9, a-v).
+  // Hex characters are a safe subset, and this stable ID makes retries idempotent.
+  return `konsensus${hex.slice(0, 48)}`;
+}
+
+function addMinutesLocal(date: string, time: string, durationMinutes: number) {
+  const [year, month, day] = date.split('-').map(Number);
+  const [hour, minute] = time.split(':').map(Number);
+
+  if (![year, month, day, hour, minute].every(Number.isFinite)) {
+    throw new Error(`Invalid meeting date/time: ${date} ${time}`);
+  }
+
+  const value = new Date(
+    Date.UTC(year, month - 1, day, hour, minute, 0, 0) + durationMinutes * 60_000,
+  );
+
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return {
+    date: `${value.getUTCFullYear()}-${pad(value.getUTCMonth() + 1)}-${pad(value.getUTCDate())}`,
+    time: `${pad(value.getUTCHours())}:${pad(value.getUTCMinutes())}`,
+  };
+}
+
+function buildDescription(meeting: MeetingRecord, publicUrl: string): string {
+  const parts: string[] = [];
+
+  if (meeting.organizer?.trim()) {
+    parts.push(`Düzenleyen: ${meeting.organizer.trim()}`);
+  }
+
+  if (meeting.description?.trim()) {
+    parts.push(meeting.description.trim());
+  }
+
+  parts.push(`Güncel katılım bilgileri:\n${publicUrl}`);
+  return parts.join('\n\n');
+}
+
+async function buildGoogleEvent(meeting: MeetingRecord, publicUrl: string) {
+  if (!meeting.id || !meeting.title?.trim() || !meeting.date) {
+    throw new Error('Meeting is missing id, title, or date');
+  }
+
+  const time = meeting.time?.trim() || '20:00';
+  const duration = Math.max(15, Number(meeting.duration) || 60);
+  const end = addMinutesLocal(meeting.date, time, duration);
+
+  return {
+    id: await deterministicEventId(meeting.id),
+    summary: meeting.title.trim(),
+    description: buildDescription(meeting, publicUrl),
+    start: {
+      dateTime: `${meeting.date}T${time}:00`,
+      timeZone: TIME_ZONE,
+    },
+    end: {
+      dateTime: `${end.date}T${end.time}:00`,
+      timeZone: TIME_ZONE,
+    },
+    status: 'confirmed',
+    transparency: 'opaque',
+    extendedProperties: {
+      private: {
+        source: 'konsensus-supabase',
+        meeting_id: String(meeting.id),
+      },
+    },
+  };
+}
+
+async function googleFetch(
+  accessToken: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<Response> {
+  return fetch(`${GOOGLE_API}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function upsertEvent(
+  accessToken: string,
+  calendarId: string,
+  meeting: MeetingRecord,
+  publicUrl: string,
+) {
+  const event = await buildGoogleEvent(meeting, publicUrl);
+  const eventId = event.id;
+  const calendar = encodeURIComponent(calendarId);
+  const encodedEventId = encodeURIComponent(eventId);
+
+  const updateResponse = await googleFetch(
+    accessToken,
+    'PUT',
+    `/calendars/${calendar}/events/${encodedEventId}?sendUpdates=none`,
+    event,
+  );
+
+  if (updateResponse.ok) return { action: 'updated', eventId };
+
+  if (updateResponse.status !== 404) {
+    const errorText = await updateResponse.text();
+    throw new Error(`Google event update failed (${updateResponse.status}): ${errorText}`);
+  }
+
+  const insertResponse = await googleFetch(
+    accessToken,
+    'POST',
+    `/calendars/${calendar}/events?sendUpdates=none`,
+    event,
+  );
+
+  if (insertResponse.ok) return { action: 'created', eventId };
+
+  // A simultaneous retry may have created the deterministic ID after our 404.
+  // In that case, retry the update rather than creating a duplicate.
+  if (insertResponse.status === 409) {
+    const retryResponse = await googleFetch(
+      accessToken,
+      'PUT',
+      `/calendars/${calendar}/events/${encodedEventId}?sendUpdates=none`,
+      event,
+    );
+    if (retryResponse.ok) return { action: 'updated-after-conflict', eventId };
+
+    const retryText = await retryResponse.text();
+    throw new Error(`Google event conflict recovery failed (${retryResponse.status}): ${retryText}`);
+  }
+
+  const errorText = await insertResponse.text();
+  throw new Error(`Google event insert failed (${insertResponse.status}): ${errorText}`);
+}
+
+async function deleteEvent(
+  accessToken: string,
+  calendarId: string,
+  meeting: MeetingRecord,
+) {
+  const eventId = await deterministicEventId(meeting.id);
+  const response = await googleFetch(
+    accessToken,
+    'DELETE',
+    `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}?sendUpdates=none`,
+  );
+
+  if (response.ok || response.status === 404 || response.status === 410) {
+    return { action: response.ok ? 'deleted' : 'already-absent', eventId };
+  }
+
+  const errorText = await response.text();
+  throw new Error(`Google event delete failed (${response.status}): ${errorText}`);
+}
+
+Deno.serve(async (request) => {
+  if (request.method !== 'POST') {
+    return jsonResponse(405, { ok: false, error: 'Method not allowed' });
+  }
+
+  try {
+    const expectedSecret = getRequiredEnv('CONSENSUS_CALENDAR_WEBHOOK_SECRET');
+    const suppliedSecret = request.headers.get('x-consensus-webhook-secret') || '';
+
+    if (suppliedSecret !== expectedSecret) {
+      return jsonResponse(401, { ok: false, error: 'Unauthorized' });
+    }
+
+    const calendarId = getRequiredEnv('GOOGLE_CALENDAR_ID');
+    const publicUrl = getRequiredEnv('CONSENSUS_PUBLIC_URL');
+    const credentials = JSON.parse(
+      getRequiredEnv('GOOGLE_SERVICE_ACCOUNT_JSON'),
+    ) as ServiceAccountCredentials;
+
+    if (!credentials.client_email || !credentials.private_key) {
+      throw new Error('GOOGLE_SERVICE_ACCOUNT_JSON is missing client_email or private_key');
+    }
+
+    const payload = (await request.json()) as WebhookPayload;
+    if (payload.schema !== 'public' || payload.table !== 'meetings') {
+      return jsonResponse(400, { ok: false, error: 'Unexpected webhook source' });
+    }
+
+    if (!['INSERT', 'UPDATE', 'DELETE'].includes(payload.type)) {
+      return jsonResponse(400, { ok: false, error: 'Unsupported webhook event' });
+    }
+
+    const meeting = payload.type === 'DELETE' ? payload.old_record : payload.record;
+    if (!meeting?.id) {
+      return jsonResponse(400, { ok: false, error: 'Webhook payload has no meeting record' });
+    }
+
+    const accessToken = await getGoogleAccessToken(credentials);
+    const result = payload.type === 'DELETE'
+      ? await deleteEvent(accessToken, calendarId, meeting)
+      : await upsertEvent(accessToken, calendarId, meeting, publicUrl);
+
+    console.log('Consensus calendar sync', {
+      webhookType: payload.type,
+      meetingId: String(meeting.id),
+      ...result,
+    });
+
+    return jsonResponse(200, { ok: true, ...result });
+  } catch (error) {
+    console.error('Consensus calendar sync failed', error);
+    return jsonResponse(500, {
+      ok: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});

--- a/supabase/migrations/20260809125500_consensus_calendar_trigger.sql
+++ b/supabase/migrations/20260809125500_consensus_calendar_trigger.sql
@@ -1,0 +1,60 @@
+create or replace function public.sync_consensus_calendar_trigger()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  webhook_secret text;
+  payload jsonb;
+  request_id bigint;
+begin
+  select decrypted_secret
+    into webhook_secret
+  from vault.decrypted_secrets
+  where name = 'consensus_calendar_webhook_secret'
+  limit 1;
+
+  if webhook_secret is null then
+    raise exception 'consensus_calendar_webhook_secret not found in Vault';
+  end if;
+
+  payload := jsonb_build_object(
+    'type', TG_OP,
+    'table', TG_TABLE_NAME,
+    'schema', TG_TABLE_SCHEMA,
+    'record',
+      case
+        when TG_OP = 'DELETE' then null
+        else to_jsonb(NEW)
+      end,
+    'old_record',
+      case
+        when TG_OP = 'INSERT' then null
+        else to_jsonb(OLD)
+      end
+  );
+
+  select net.http_post(
+    url := 'https://anawjzyrgxtfxqzczwwm.supabase.co/functions/v1/sync-consensus-calendar',
+    body := payload,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-consensus-webhook-secret', webhook_secret
+    ),
+    timeout_milliseconds := 10000
+  )
+  into request_id;
+
+  return null;
+end;
+$$;
+
+drop trigger if exists sync_consensus_calendar_webhook
+on public.meetings;
+
+create trigger sync_consensus_calendar_webhook
+after insert or update or delete
+on public.meetings
+for each row
+execute function public.sync_consensus_calendar_trigger();

--- a/supabase/scripts/backfill_consensus_calendar.sql
+++ b/supabase/scripts/backfill_consensus_calendar.sql
@@ -1,0 +1,55 @@
+-- One-time/re-runnable backfill for existing upcoming meetings.
+-- Does not UPDATE the meetings table, so unrelated UPDATE triggers/notifications are not fired.
+-- Safe to rerun because the Edge Function uses deterministic Google event IDs.
+
+with webhook_secret as (
+  select decrypted_secret
+  from vault.decrypted_secrets
+  where name = 'consensus_calendar_webhook_secret'
+  limit 1
+), upcoming as (
+  select
+    m.id,
+    m.title,
+    m.organizer,
+    m.date,
+    m.time,
+    m.duration,
+    m.description,
+    s.decrypted_secret as webhook_secret
+  from public.meetings m
+  cross join webhook_secret s
+  where (
+    m.date || ' ' || coalesce(nullif(m.time, ''), '20:00')
+  )::timestamp >= (now() at time zone 'Europe/Istanbul')
+)
+select
+  id,
+  title,
+  date,
+  time,
+  net.http_post(
+    url := 'https://anawjzyrgxtfxqzczwwm.supabase.co/functions/v1/sync-consensus-calendar',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-consensus-webhook-secret', webhook_secret
+    ),
+    body := jsonb_build_object(
+      'type', 'INSERT',
+      'table', 'meetings',
+      'schema', 'public',
+      'record', jsonb_build_object(
+        'id', id,
+        'title', title,
+        'organizer', organizer,
+        'date', date,
+        'time', time,
+        'duration', duration,
+        'description', description
+      ),
+      'old_record', null
+    ),
+    timeout_milliseconds := 10000
+  ) as request_id
+from upcoming
+order by date, time;


### PR DESCRIPTION
## What changed

- Added an optional **Google Takvim’de takip et** entry to the Konsensus notification card.
- Added the public calendar URL environment variable.
- Added a Supabase Edge Function at `supabase/functions/sync-consensus-calendar/index.ts`.
- Added function config with `verify_jwt = false` for the webhook receiver.
- Added idempotent Google Calendar create/update/delete synchronization using deterministic event IDs derived from the Supabase meeting ID.
- Documented the dedicated Google account, service account, calendar sharing model, Supabase secrets, webhook setup, Bolt public information URL, and security model.

## Architecture

`Konsensus Yönetim -> Supabase meetings -> Database Webhook -> Edge Function -> Google Calendar -> followers`

Supabase `meetings` remains the single source of truth. Google Calendar is only a published mirror.

## Security

- Google Calendar access uses a dedicated service account, not a personal Google login.
- Service-account private key JSON is stored only as a Supabase secret and is never committed.
- The webhook endpoint skips Supabase JWT verification but requires a private `x-consensus-webhook-secret` header before doing any work.
- Zoom URL, meeting ID, and password are never copied to Google Calendar.
- Calendar event descriptions point to `https://konsensus.bolt.host/` for current participation information.

## Idempotency

No `google_event_id` database column is required. A stable Google event ID is generated from each Supabase meeting ID, so webhook retries do not create duplicates and DELETE can recover the same event ID without extra database state.

## Remaining deployment steps

1. Add all four Supabase Edge Function secrets: `GOOGLE_CALENDAR_ID`, `GOOGLE_SERVICE_ACCOUNT_JSON`, `CONSENSUS_PUBLIC_URL`, and `CONSENSUS_CALENDAR_WEBHOOK_SECRET`.
2. Deploy `sync-consensus-calendar` with JWT verification disabled.
3. Create an INSERT/UPDATE/DELETE Database Webhook for `public.meetings` with the shared secret header.
4. Verify create/update/delete with a test meeting.
5. Backfill existing upcoming meetings.
6. Configure the production `VITE_CONSENSUS_CALENDAR_URL` and merge after validation.
