### PR TITLE
Add mobile guidance to Konsensus notifications

### DIFF
--- a/src/components/Konsensus/NotificationsCard.tsx
+++ b/src/components/Konsensus/NotificationsCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Bell, CalendarDays, ChevronDown, ExternalLink, Send } from 'lucide-react';
+import { Bell, CalendarDays, ChevronDown, ExternalLink, Send, Smartphone } from 'lucide-react';
 
 const TELEGRAM_URL = 'https://t.me/konsensustakip';
 const GOOGLE_CALENDAR_URL = 'https://calendar.google.com/calendar/u/0?cid=YTZmOTYwZDE3ZTQ1ZDYxODU3NDI2NTc3ZTE1YzU4NDkzZTc2ZjY5ZmRmOGU2MmFlMTFkMmFlMjM4MTQwZDgyZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t';
@@ -41,6 +41,15 @@ export function NotificationsCard({
 
             {open && (
                 <div className="border-t border-gray-100 p-4 space-y-3">
+                    <div className="sm:hidden flex items-start gap-3 rounded-xl border border-amber-100 bg-amber-50 p-3">
+                        <Smartphone className="w-5 h-5 text-amber-700 shrink-0 mt-0.5" />
+                        <div className="text-xs text-amber-900 leading-relaxed">
+                            <div className="font-black mb-1">Telefondan takip</div>
+                            <div>Telegram ve tarayıcı bildirimi hemen kullanılabilir.</div>
+                            <div className="mt-1">Google Takvim’in ilk aboneliğini bilgisayardan yapın; iPhone’da iCal ile telefondan ekleyebilirsiniz.</div>
+                        </div>
+                    </div>
+
                     <div className="flex items-start gap-3 rounded-xl bg-blue-50/60 p-3">
                         <Bell className="w-5 h-5 text-blue-700 shrink-0 mt-0.5" />
                         <div className="min-w-0 flex-1">


### PR DESCRIPTION
Adds a compact mobile-only guidance note inside the expanded “Bildirim ve Takip” panel:

- Telegram and browser notifications can be used immediately on the phone.
- Google Calendar's first subscription is guided to desktop.
- iPhone users are told they can add the public iCal feed directly from the phone.

The note is hidden on larger screens to avoid extra clutter.