### PR TITLE
Separate Google and iPhone calendar guidance

### DIFF
--- a/src/components/Konsensus/NotificationsCard.tsx
+++ b/src/components/Konsensus/NotificationsCard.tsx
@@ -41,15 +41,6 @@ export function NotificationsCard({
 
             {open && (
                 <div className="border-t border-gray-100 p-4 space-y-3">
-                    <div className="sm:hidden flex items-start gap-3 rounded-xl border border-amber-100 bg-amber-50 p-3">
-                        <Smartphone className="w-5 h-5 text-amber-700 shrink-0 mt-0.5" />
-                        <div className="text-xs text-amber-900 leading-relaxed">
-                            <div className="font-black mb-1">Telefondan takip</div>
-                            <div>Telegram ve tarayıcı bildirimi hemen kullanılabilir.</div>
-                            <div className="mt-1">Google Takvim’in ilk aboneliğini bilgisayardan yapın; iPhone’da iCal ile telefondan ekleyebilirsiniz.</div>
-                        </div>
-                    </div>
-
                     <div className="flex items-start gap-3 rounded-xl bg-blue-50/60 p-3">
                         <Bell className="w-5 h-5 text-blue-700 shrink-0 mt-0.5" />
                         <div className="min-w-0 flex-1">
@@ -94,16 +85,35 @@ export function NotificationsCard({
                     <div className="flex items-start gap-3 rounded-xl bg-emerald-50/60 p-3">
                         <CalendarDays className="w-5 h-5 text-emerald-700 shrink-0 mt-0.5" />
                         <div className="min-w-0 flex-1">
-                            <div className="font-black text-sm text-gray-900">Takvim</div>
-                            <p className="text-xs text-gray-500 mt-1">Toplantılar ve tarih-saat değişiklikleri takviminize yansısın.</p>
+                            <div className="font-black text-sm text-gray-900">Google Takvim</div>
+                            <p className="text-xs text-gray-500 mt-1">
+                                Toplantılar ve tarih-saat değişiklikleri takviminize yansısın. Google Takvim’in ilk aboneliği bilgisayardan yapılmalı.
+                            </p>
+                            <a
+                                href={GOOGLE_CALENDAR_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-black hover:bg-emerald-700 transition"
+                            >
+                                Google Takvim’e ekle
+                                <ExternalLink className="w-3.5 h-3.5" />
+                            </a>
+                        </div>
+                    </div>
+
+                    <div className="flex items-start gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3">
+                        <Smartphone className="w-5 h-5 text-gray-700 shrink-0 mt-0.5" />
+                        <div className="min-w-0 flex-1">
+                            <div className="font-black text-sm text-gray-900">iPhone / Apple Takvim</div>
+                            <p className="text-xs text-gray-500 mt-1">iPhone’da public iCal bağlantısını kullanarak telefondan abone olabilirsiniz.</p>
                             <div className="mt-2 flex flex-wrap gap-2">
                                 <a
-                                    href={GOOGLE_CALENDAR_URL}
+                                    href={ICAL_URL}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-black hover:bg-emerald-700 transition"
+                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-900 text-white text-xs font-black hover:bg-gray-800 transition"
                                 >
-                                    Google Takvim
+                                    iPhone / Apple Takvim’e ekle
                                     <ExternalLink className="w-3.5 h-3.5" />
                                 </a>
                                 <a
@@ -112,7 +122,7 @@ export function NotificationsCard({
                                     rel="noopener noreferrer"
                                     className="inline-flex items-center px-3 py-1.5 rounded-lg bg-white text-gray-600 border border-gray-200 text-xs font-bold hover:bg-gray-50 transition"
                                 >
-                                    iCal / Outlook
+                                    Outlook / iCal
                                 </a>
                             </div>
                         </div>


### PR DESCRIPTION
Refines the Konsensus notification panel:

- Uses the same content on mobile and desktop.
- Keeps Google Calendar as its own section with the note that first subscription should be done from a computer.
- Adds a separate iPhone / Apple Calendar section using the public iCal feed.
- Keeps Outlook / iCal as a secondary option.

This reduces ambiguity between Google Calendar and Apple Calendar subscription paths.